### PR TITLE
Add support for Docker secrets

### DIFF
--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -ea
 
+# Allow sensitive settings to be defined in a file
+# in order to support Docker secrets
+if [ -n "${DATABASE__PASSWORD_FILE}" ]; then
+  DATABASE_PASSWORD=$(cat "$DATABASE_PASSWORD_FILE")
+  export DATABASE_PASSWORD
+fi
+
 if [ "$1" = "strapi" ]; then
 
   if [ ! -f "package.json" ]; then

--- a/strapi/docker-entrypoint.sh
+++ b/strapi/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -ea
 
 # Allow sensitive settings to be defined in a file
 # in order to support Docker secrets
-if [ -n "${DATABASE__PASSWORD_FILE}" ]; then
+if [ -n "${DATABASE_PASSWORD_FILE}" ]; then
   DATABASE_PASSWORD=$(cat "$DATABASE_PASSWORD_FILE")
   export DATABASE_PASSWORD
 fi


### PR DESCRIPTION
Allow database password to be defined in a file via the `DATABASE_PASSWORD_FILE` environment variable.
This adds support for Docker secrets in a Docker swarm.

Typical use would be as follows (this assumes the 1database-password` secret has been created outside of the strapi stack):

```
#docker-compsoe.yml
version: "3"

secrets:
  database-password:
    external: true

services:
  strapi:
    container_name: strapi
    image: strapi/strapi
    environment:
      - NODE_ENV=production
      - DATABASE_CLIENT=postgres
      - DATABASE_HOST=db
      - DATABASE_PORT=5432
      - DATABASE_NAME=strapi
      - DATABASE_USERNAME=strapi
      - DATABASE_PASSWORD=/run/secrets/database-password
    ports:
      - 1337:1337
    volumes:
      - ./app:/srv/app
    secrets:
      - database-password
    depends_on:
      - db
    command: 'strapi start'
```